### PR TITLE
Add demo sewing services website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # project
 using this for the project creation
+
+## Sewing services demo website
+A static demo site was added in `sewing-services-demo/`.
+
+### Run locally
+Open `sewing-services-demo/index.html` in your browser.

--- a/sewing-services-demo/index.html
+++ b/sewing-services-demo/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stitch & Style Sewing Services</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Source+Sans+3:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="nav container">
+        <div class="logo">Stitch & Style</div>
+        <a class="btn btn-small" href="#book">Book a Fitting</a>
+      </nav>
+      <div class="hero-content container">
+        <p class="eyebrow">Custom Tailoring • Alterations • Repairs</p>
+        <h1>Bring new life to every piece in your closet.</h1>
+        <p>
+          Professional sewing services for everyday wear, formal attire, and
+          one-of-a-kind designs. Fast turnarounds with quality craftsmanship.
+        </p>
+        <div class="hero-actions">
+          <a class="btn" href="#services">View Services</a>
+          <a class="btn btn-secondary" href="#contact">Get a Quote</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="section container" id="services">
+        <div class="section-heading">
+          <h2>Popular Sewing Services</h2>
+          <p>
+            From hemming jeans to custom wedding gown alterations, we tailor
+            each service to your exact fit.
+          </p>
+        </div>
+        <div class="cards">
+          <article class="card">
+            <h3>Alterations</h3>
+            <p>
+              Precise resizing, hemming, tapering, and fit adjustments for all
+              garment types.
+            </p>
+            <span>Starting at $20</span>
+          </article>
+          <article class="card">
+            <h3>Repairs</h3>
+            <p>
+              Zipper replacements, seam repairs, patching, and restoration work
+              that lasts.
+            </p>
+            <span>Starting at $15</span>
+          </article>
+          <article class="card">
+            <h3>Custom Pieces</h3>
+            <p>
+              Turn your vision into reality with bespoke dresses, suits, and
+              special event garments.
+            </p>
+            <span>Starting at $120</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section-highlight" id="book">
+        <div class="container split">
+          <div>
+            <h2>Simple 3-step fitting process</h2>
+            <ol>
+              <li>Send your request and photos through our quick form.</li>
+              <li>Book a consultation for measurements and fabric guidance.</li>
+              <li>Pick up your finished piece or request local delivery.</li>
+            </ol>
+          </div>
+          <form class="quote-form" id="quote-form">
+            <h3>Request a quote</h3>
+            <label>
+              Name
+              <input type="text" name="name" placeholder="Your name" required />
+            </label>
+            <label>
+              Email
+              <input
+                type="email"
+                name="email"
+                placeholder="you@example.com"
+                required
+              />
+            </label>
+            <label>
+              Service needed
+              <select name="service" required>
+                <option value="">Select one</option>
+                <option>Alterations</option>
+                <option>Repair</option>
+                <option>Custom Piece</option>
+              </select>
+            </label>
+            <label>
+              Notes
+              <textarea
+                name="notes"
+                rows="3"
+                placeholder="Tell us about your garment and timeline"
+              ></textarea>
+            </label>
+            <button type="submit" class="btn">Send Request</button>
+            <p class="form-message" id="form-message" aria-live="polite"></p>
+          </form>
+        </div>
+      </section>
+
+      <section class="section container testimonials" id="contact">
+        <div class="section-heading">
+          <h2>What clients say</h2>
+        </div>
+        <blockquote>
+          “I brought in my bridal gown one week before the wedding and it fit
+          perfectly. The team was kind, quick, and incredibly detail-oriented.”
+        </blockquote>
+        <p class="attribution">— Maya R.</p>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer-grid">
+        <div>
+          <h3>Stitch & Style</h3>
+          <p>Downtown Studio • Mon–Sat, 9:00 AM – 6:00 PM</p>
+        </div>
+        <div>
+          <p>Email: hello@stitchstyle.demo</p>
+          <p>Phone: (555) 010-4455</p>
+        </div>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/sewing-services-demo/script.js
+++ b/sewing-services-demo/script.js
@@ -1,0 +1,10 @@
+const quoteForm = document.getElementById('quote-form');
+const message = document.getElementById('form-message');
+
+quoteForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(quoteForm);
+  const name = formData.get('name');
+  message.textContent = `Thanks${name ? `, ${name}` : ''}! We'll reach out within one business day.`;
+  quoteForm.reset();
+});

--- a/sewing-services-demo/styles.css
+++ b/sewing-services-demo/styles.css
@@ -1,0 +1,211 @@
+:root {
+  --bg: #fff9f4;
+  --panel: #ffffff;
+  --text: #2f2634;
+  --muted: #6f6176;
+  --brand: #a74767;
+  --brand-dark: #863451;
+  --accent: #f1dfeb;
+  --shadow: 0 10px 30px rgba(55, 31, 52, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Source Sans 3', system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.75rem;
+  font-family: 'Playfair Display', Georgia, serif;
+}
+
+.container {
+  width: min(1080px, 90vw);
+  margin: 0 auto;
+}
+
+.hero {
+  color: #fff;
+  background: linear-gradient(145deg, rgba(134, 52, 81, 0.9), rgba(70, 28, 47, 0.92)),
+    url('https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=1400&q=60')
+      center / cover;
+  padding-bottom: 4rem;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 0;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.hero-content {
+  max-width: 680px;
+  padding: 3rem 0 1rem;
+}
+
+.hero-content h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.1;
+}
+
+.eyebrow {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.btn {
+  display: inline-block;
+  border: none;
+  border-radius: 999px;
+  background: var(--brand);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  padding: 0.72rem 1.3rem;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.btn:hover {
+  background: var(--brand-dark);
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.btn-small {
+  padding: 0.55rem 1rem;
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section-heading {
+  margin-bottom: 2rem;
+}
+
+.section-heading p {
+  max-width: 640px;
+  color: var(--muted);
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.card {
+  background: var(--panel);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.card span {
+  font-weight: 700;
+  color: var(--brand);
+}
+
+.section-highlight {
+  background: var(--accent);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+ol {
+  padding-left: 1.2rem;
+}
+
+.quote-form {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  margin-top: 0.35rem;
+  border: 1px solid #d5c8d4;
+  border-radius: 0.55rem;
+  padding: 0.6rem;
+  font: inherit;
+}
+
+.form-message {
+  min-height: 1.3rem;
+  margin-top: 0.6rem;
+  color: var(--brand-dark);
+  font-weight: 600;
+}
+
+.testimonials blockquote {
+  margin: 0;
+  font-size: 1.2rem;
+  max-width: 720px;
+}
+
+.attribution {
+  color: var(--muted);
+}
+
+.footer {
+  background: #2d1d29;
+  color: #f4eef2;
+  padding: 2rem 0;
+}
+
+.footer-grid {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 860px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a ready-made static demo site to showcase a sewing services landing page and speed up prototyping and visual reviews.
- Offer a simple, local example of a marketing-focused layout with a booking/quote flow to demonstrate UI and copy for the project.

### Description
- Add a new static demo site under `sewing-services-demo/` with `index.html` containing a hero, services cards, booking/process section, testimonial, and footer contact info.
- Add responsive styling in `sewing-services-demo/styles.css` including brand colors, layout, card styles, and a mobile breakpoint.
- Add a small client-side interaction in `sewing-services-demo/script.js` that intercepts the quote form submit, shows a thank-you message, and resets the form.
- Update `README.md` to document the demo location and how to run it locally, and commit the files.

### Testing
- Run `node --check sewing-services-demo/script.js`, which completed successfully.
- Verified repository status with `git status --short` after committing the added files, with no outstanding changes reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6654a64588331adbabddb67c758b9)